### PR TITLE
add LTTNGCONSUME_ENABLE_TESTING config option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.7)
 
 project(lttng-consume)
 
+set(LTTNGCONSUME_ENABLE_TESTING TRUE CACHE BOOL "build test dir" )
+
 if (NOT TARGET nonstd::string_view-lite)
     add_subdirectory(external/string-view-lite)
 endif ()
@@ -13,22 +15,22 @@ if (NOT TARGET jsonbuilder)
     add_subdirectory(external/JsonBuilder)
 endif()
 
-if (NOT TARGET tracelogging)
-    add_subdirectory(external/TraceLogging)
-endif()
-
 add_compile_options(-Wall -Wextra -Werror)
 
 add_subdirectory(src)
 
 # Only include testing stuff if we are the top level
-if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+if (${LTTNGCONSUME_ENABLE_TESTING} AND ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     enable_testing()
 
     if (NOT TARGET Catch2::Catch2)
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2/contrib")
         add_subdirectory(external/Catch2)
     endif ()
+
+    if (NOT TARGET tracelogging)
+        add_subdirectory(external/TraceLogging)
+    endif()
 
     add_subdirectory(test)
 endif ()


### PR DESCRIPTION
Add LTTNGCONSUME_ENABLE_TESTING config option to disable building the test directory and test only dependencies. Default is TRUE, must be explicitly set to false to turn on new build behavior