### PR TITLE
Fix missing include

### DIFF
--- a/src/LttngConsumerImpl.h
+++ b/src/LttngConsumerImpl.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <string>
 #include <string_view>
 
 #include "BabelPtr.h"


### PR DESCRIPTION
Missing include exposes when building with libstdc++-10, which pulls in header dependencies in a slightly different order and fails to build.